### PR TITLE
Fix permissions issue on GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,8 @@ jobs:
   build:
     name: main
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - if: ${{ startsWith(github.event_name, 'repository_dispatch') }}
         run: sleep 30


### PR DESCRIPTION
I noticed that the pre-commit hook was lagging behind the releases of the main repo, and looking at the actions tab, it seems to be [permissions related](https://github.com/gauge-sh/tach-pre-commit/actions/runs/9519207049/job/26241886095#step:10:15).

It looks it might be because the `GITHUB_TOKEN` is missing [write access to the repo content](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs)? Not sure how it works on the ruff repo though...