### PR TITLE
Add hook to run check-external

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,3 +4,9 @@
   entry: tach check
   language: python
   pass_filenames: false
+- id: tach-external
+  name: tach-external
+  description: Validate external package dependencies
+  entry: tach check-external
+  language: python
+  pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Distributed as a standalone repository to enable installing Tach via prebuilt wh
 
 ### Using Tach with pre-commit
 
-To run `tach check` via pre-commit, add the following to your `.pre-commit-config.yaml`:
+To run [`tach check`](https://docs.gauge.sh/usage/commands#tach-check) and [`tach check-external`](https://docs.gauge.sh/usage/commands#tach-check-external) via pre-commit, add the following to your `.pre-commit-config.yaml`:
 
 ```yaml
 - repo: https://github.com/gauge-sh/tach-pre-commit
@@ -15,4 +15,7 @@ To run `tach check` via pre-commit, add the following to your `.pre-commit-confi
   rev: v0.14a0
   hooks:
     - id: tach
+    - id: tach-external
 ```
+
+Use [`args`](https://pre-commit.com/#config-args) to pass additional arguments to the `tach` commands.


### PR DESCRIPTION
This patch adds a hook to run [`tach check-external`](https://docs.gauge.sh/usage/commands#tach-check-external).

In some cases, this causes issues because the hook runs in an isolated environment and thus cannot use metadata to figure out package names from distribution names. This could be improved with the fix mentioned in https://github.com/gauge-sh/tach/issues/414#issuecomment-2484519585.