### PR TITLE
Fix mirror readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To run `tach check` via pre-commit, add the following to your `.pre-commit-confi
 ```yaml
 - repo: https://github.com/gauge-sh/tach-pre-commit
   # Tach version.
-  rev: v0.14a0
+  rev: v0.15.2
   hooks:
     - id: tach
 ```

--- a/mirror.py
+++ b/mirror.py
@@ -54,7 +54,7 @@ def process_version(version: Version) -> typing.Sequence[str]:
         return re.sub(r'"tach==.*"', f'"tach=={version}"', content)
 
     def replace_readme_md(content: str) -> str:
-        return re.sub(r"rev: v\d+\.\d+\.\d+", f"rev: v{version}", content)
+        return re.sub(r"rev: v\d+\.\d+(?:\.|[a-z]+)\d+", f"rev: v{version}", content)
 
     paths = {
         "pyproject.toml": replace_pyproject_toml,


### PR DESCRIPTION
On [0.14.3](https://github.com/gauge-sh/tach-pre-commit/tree/v0.14.3), the README is stuck at 0.14a0 because the substitution match in `mirror.py` doesn't update from versions that don't match `x.y.z`.

This patch quickly fixes this (I don't know what the versioning scheme is), and updates the README to the latest `tach` release.